### PR TITLE
Update coupon redemption post registration

### DIFF
--- a/getting_started/choose_a_plan.adoc
+++ b/getting_started/choose_a_plan.adoc
@@ -63,8 +63,8 @@ You can also redeem coupons after the registration process:
 . On the next *Subscriptions* page, click *Manage* next to the *Coupons* heading.
 
 . On the next *Subscription Coupons* page, you will see (if applicable) coupons
-that are available for you to use and those that are already in use.  To apply a
-new coupon, click *Apply New Coupon* and complete the workflow.
+that you have already redeemed for this subscription. To apply a new coupon,
+click *Apply New Coupon* and complete the workflow.
 
 [[getting-started-next-up-basic-walkthrough]]
 == Next Up: Basic Walkthrough


### PR DESCRIPTION
The Subscription's coupon page no longer lists coupons restricted to the
subscription along with those already applied. This updates the text to
reflect the new changes.:wq